### PR TITLE
M2M Select via shared relations_sql.SOURCE mixin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/service
 
 COPY requirements.txt .
 
-RUN pip install -r requirements.txt
+RUN apk add git && pip install -r requirements.txt
 
 COPY setup.py .
 COPY lib lib

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ACCOUNT=gaf3
 IMAGE=python-relations-psycopg2
 INSTALL=python:3.8.5-alpine3.12
-VERSION?=0.6.9
+VERSION?=0.6.10
 NETWORK=relations.io
 POSTGRES_IMAGE=postgres:12.4-alpine
 POSTGRES_HOST=$(ACCOUNT)-$(IMAGE)-postgres

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,7 @@ lint:
 
 setup:
 	docker run $(TTY) $(VOLUMES) $(PYPI) $(INSTALL) sh -c "cp -r /opt/service /opt/install && cd /opt/install/ && \
-	apk update && apk add git gcc libc-dev make libpq postgresql-dev build-base && \
-	pip install \
-		git+https://github.com/relations-dil/python-relations.git@0.6.9#egg=python-relations \
-		git+https://github.com/relations-dil/python-relations-sql.git@0.6.5#egg=python-relations-sql \
-		git+https://github.com/relations-dil/python-relations-postgresql.git@0.6.0#egg=python-relations-postgresql && \
+	apk update && apk add gcc libc-dev make libpq postgresql-dev build-base && \
 	python setup.py install && \
 	python -m relations_psycopg2"
 

--- a/lib/relations_psycopg2.py
+++ b/lib/relations_psycopg2.py
@@ -533,6 +533,19 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
 
             delete_query = query or self.delete_query(model)
 
+            if model._id:
+
+                store_id = model._fields._names[model._id].store
+
+                id_query = self.SELECT(store_id, WHERE=delete_query.WHERE).FROM(self.TABLE_NAME(model.STORE, schema=model.SCHEMA))
+
+                id_query.generate()
+
+                cursor.execute(id_query.sql, id_query.args)
+                ids = [row[store_id] for row in cursor.fetchall()]
+
+                self.delete_ties(model, ids)
+
         elif model._id:
 
             delete_query = self.delete_query(model)

--- a/lib/relations_psycopg2.py
+++ b/lib/relations_psycopg2.py
@@ -15,7 +15,7 @@ import relations
 import relations_sql
 import relations_postgresql
 
-class Source(relations.Source): # pylint: disable=too-many-public-methods
+class Source(relations_sql.SOURCE, relations.Source): # pylint: disable=too-many-public-methods
     """
     PsycoPg2 Source
     """
@@ -269,6 +269,7 @@ class Source(relations.Source): # pylint: disable=too-many-public-methods
         query = self.SELECT(self.AS("total", self.SQL("COUNT(*)"))).FROM(self.TABLE_NAME(model.STORE, schema=model.SCHEMA))
 
         model._collate()
+        self.collate_ties_query(model, query)
         self.retrieve_record(model._record, query)
         self.like(model, query)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
-relations-dil==0.6.12
-relations-postgresql==0.6.2
+# relations-dil==0.6.14
+# relations-sql==0.6.8
+# relations-postgresql==0.6.3
+relations-dil @ git+https://github.com/relations-dil/python-relations@09f27c34eb079dd29042cb9460b140fea336b9f3
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
+relations-postgresql @ git+https://github.com/relations-dil/python-relations-postgresql@d48d00dfa1d4cace6ddfef86256188cc94ec8403
 psycopg2==2.8.6
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # relations-dil==0.6.14
 # relations-sql==0.6.8
 # relations-postgresql==0.6.3
-relations-dil @ git+https://github.com/relations-dil/python-relations@09f27c34eb079dd29042cb9460b140fea336b9f3
+relations-dil @ git+https://github.com/relations-dil/python-relations@ab8af7bb24bceab2286175c8df5626137294f46d
 relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
 relations-postgresql @ git+https://github.com/relations-dil/python-relations-postgresql@d48d00dfa1d4cace6ddfef86256188cc94ec8403
 psycopg2==2.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-# relations-dil==0.6.14
-# relations-sql==0.6.8
-# relations-postgresql==0.6.3
-relations-dil @ git+https://github.com/relations-dil/python-relations@7b83a060fcd41ee2ae81bb63aae5fc6a7e530cfa
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@3a6698ab9f77de75ee729aa6b5608fc6db69c286
-relations-postgresql @ git+https://github.com/relations-dil/python-relations-postgresql@d48d00dfa1d4cace6ddfef86256188cc94ec8403
+relations-dil==0.6.14
+relations-sql==0.6.8
+relations-postgresql==0.6.3
 psycopg2==2.8.6
 ptvsd==4.3.2
 coverage==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # relations-dil==0.6.14
 # relations-sql==0.6.8
 # relations-postgresql==0.6.3
-relations-dil @ git+https://github.com/relations-dil/python-relations@ab8af7bb24bceab2286175c8df5626137294f46d
-relations-sql @ git+https://github.com/relations-dil/python-relations-sql@c0e672d97e2b5a8ed3505f7c9cf734fee2e29881
+relations-dil @ git+https://github.com/relations-dil/python-relations@7b83a060fcd41ee2ae81bb63aae5fc6a7e530cfa
+relations-sql @ git+https://github.com/relations-dil/python-relations-sql@3a6698ab9f77de75ee729aa6b5608fc6db69c286
 relations-postgresql @ git+https://github.com/relations-dil/python-relations-postgresql@d48d00dfa1d4cace6ddfef86256188cc94ec8403
 psycopg2==2.8.6
 ptvsd==4.3.2

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ with open("README.md", "r") as readme_file:
 
 setup(
     name="relations-psycopg2",
-    version="0.6.9",
+    version="0.6.10",
     package_dir = {'': 'lib'},
     py_modules = [
         'relations_psycopg2'
     ],
     install_requires=[
         'psycopg2==2.8.6',
-        'relations-dil>=0.6.12',
-        'relations-postgresql>=0.6.2'
+        'relations-dil>=0.6.14',
+        'relations-postgresql>=0.6.3'
     ],
     url="https://github.com/relations-dil/python-relations-psycopg2",
     author="Gaffer Fitch",

--- a/test/test_relations_psycopg2.py
+++ b/test/test_relations_psycopg2.py
@@ -84,6 +84,23 @@ class Case(SourceModel):
 relations.OneToMany(Unit, Test)
 relations.OneToOne(Test, Case)
 
+class Sis(SourceModel):
+    id = int
+    name = str
+    bro_id = set
+
+class Bro(SourceModel):
+    id = int
+    name = str
+    sis_id = set
+
+class SisBro(SourceModel):
+    ID = None
+    bro_id = int
+    sis_id = int
+
+relations.ManyToMany(Sis, Bro, SisBro)
+
 class TestSource(unittest.TestCase):
 
     maxDiff = None
@@ -218,6 +235,12 @@ CREATE UNIQUE INDEX "simple_name" ON "test_source"."simple" ("name");
         model = Simple([["sure"], ["fine"]])
         self.assertRaisesRegex(relations.ModelError, "only one create query at a time", model.query)
 
+        query = Sis("sure", bro_id=[1, 2, 3]).query()
+        query.generate()
+
+        self.assertEqual(query.sql, """INSERT INTO "test_source"."sis" ("name") VALUES (%s)""")
+        self.assertEqual(query.args, ["sure"])
+
     def test_create_id(self):
 
         self.source.execute(Simple.define())
@@ -281,6 +304,22 @@ CREATE UNIQUE INDEX "simple_name" ON "test_source"."simple" ("name");
             "things": {"for": [{"1": "yep"}]},
             "things__for__0____1": "yep"
         })
+
+        sis = Sis("Sally", bro_id=[2, 3, 4], _bulk=True)
+        self.assertRaisesRegex(relations.ModelError, "cannot create ties in bulk", sis.create)
+
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        sis = Sis("Sally", bro_id=[2, 3, 4]).create()
+
+        cursor.execute("SELECT * FROM test_source.sis_bro ORDER BY bro_id")
+        self.assertEqual(cursor.fetchall(), [
+            {"sis_id": sis.id, "bro_id": 2},
+            {"sis_id": sis.id, "bro_id": 3},
+            {"sis_id": sis.id, "bro_id": 4}
+        ])
 
         cursor.close()
 
@@ -588,6 +627,9 @@ LIMIT %s""")
 
         self.assertEqual(Unit.many(like="p").count(), 1)
 
+        sis = Sis.many(bro_id=[2, 3, 4])
+        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.count)
+
     def test_values_retrieve(self):
 
         model = unittest.mock.MagicMock()
@@ -636,6 +678,9 @@ LIMIT %s""")
         self.source.execute(Case.define())
         self.source.execute(Meta.define())
         self.source.execute(Net.define())
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
 
         Unit([["stuff"], ["people"]]).create()
 
@@ -794,6 +839,21 @@ LIMIT %s""")
         model = Net.many(subnet__max_value=int(ipaddress.IPv4Address('1.2.3.0')))
         self.assertEqual(len(model), 0)
 
+        sis = Sis.many(bro_id=[2, 3, 4])
+        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.retrieve)
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+
+        dot = Sis("Dot").create()
+        nikki = Sis("Nikki").create()
+
+        mary = Sis("Mary", bro_id=[tom.id, dick.id]).create()
+        harry = Bro("Harry", sis_id=[dot.id, nikki.id]).create()
+
+        self.assertEqual(mary.bro.id, [dick.id, tom.id])
+        self.assertEqual(harry.sis.id, [dot.id, nikki.id])
+
     def test_titles(self):
 
         self.source.execute(Unit.define())
@@ -801,6 +861,9 @@ LIMIT %s""")
         self.source.execute(Case.define())
         self.source.execute(Meta.define())
         self.source.execute(Net.define())
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
 
         Unit("people").create().test.add("stuff").add("things").create()
 
@@ -837,6 +900,9 @@ LIMIT %s""")
         self.assertEqual(Net.many().titles().titles, {
             1: ["1.2.3.4"]
         })
+
+        sis = Sis.many(bro_id=[2, 3, 4])
+        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.titles)
 
     def test_update_field(self):
 
@@ -901,6 +967,9 @@ LIMIT %s""")
         self.source.execute(Case.define())
         self.source.execute(Meta.define())
         self.source.execute(Net.define())
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
 
         Unit([["people"], ["stuff"]]).create()
 
@@ -943,6 +1012,26 @@ LIMIT %s""")
         self.assertEqual(Net.one(ping.id).ip.compressed, "13.14.15.16")
         self.assertEqual(Net.one(pong.id).ip.compressed, "5.6.7.8")
 
+        sis = Sis.many(name="Sally").set(bro_id=[1, 2, 3])
+        self.assertRaisesRegex(relations.ModelError, "cannot update ties in retrieve mode", sis.update)
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+
+        dot = Sis("Dot").create()
+        nikki = Sis("Nikki").create()
+
+        tom.sis_id = [nikki.id, dot.id]
+        dot.bro_id = [tom.id, dick.id]
+
+        tom.update()
+        dot.update()
+
+        self.assertEqual(Bro.one(name="Tom").sis.id, [dot.id, nikki.id])
+        self.assertEqual(Sis.one(name="Dot").bro.id, [dick.id, tom.id])
+        self.assertEqual(Bro.one(name="Dick").sis.id, [dot.id])
+        self.assertEqual(Sis.one(name="Nikki").bro.id, [tom.id])
+
     def test_delete_query(self):
 
         self.source.execute(Unit.define())
@@ -974,6 +1063,9 @@ LIMIT %s""")
         self.source.execute(Test.define())
         self.source.execute(Case.define())
         self.source.execute(Plain.define())
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
 
         unit = Unit("people")
         unit.test.add("stuff").add("things")
@@ -991,6 +1083,27 @@ LIMIT %s""")
 
         plain = Plain(0, "nope").create()
         self.assertRaisesRegex(relations.ModelError, "plain: nothing to delete from", plain.delete)
+
+        self.assertRaisesRegex(relations.ModelError, "cannot delete ties in retrieve mode", Sis.many().delete)
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+
+        dot = Sis("Dot").create()
+        nikki = Sis("Nikki").create()
+
+        tom.sis_id = [nikki.id, dot.id]
+        dot.bro_id = [tom.id, dick.id]
+
+        tom.update()
+        dot.update()
+
+        dick.one(name="Dick").retrieve().delete()
+        nikki.one(name="Nikki").retrieve().delete()
+
+        self.assertEqual(Bro.one(name="Tom").sis.id, [dot.id])
+        self.assertEqual(Sis.one(name="Dot").bro.id, [tom.id])
+        self.assertEqual(SisBro.many().count(), 1)
 
     def test_definition(self):
 

--- a/test/test_relations_psycopg2.py
+++ b/test/test_relations_psycopg2.py
@@ -1093,9 +1093,10 @@ LIMIT %s""")
         bro = Bro("Harry").create()
         Sis.many(name="Sally").set(bro_id=[bro.id]).update()
 
-        Sis.one(name="Sally").delete()
+        Sis.many(name="Sally").delete()
 
         self.assertEqual(Bro.one(name="Harry").sis.id, [])
+        self.assertEqual(SisBro.many().count(), 0)
 
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()

--- a/test/test_relations_psycopg2.py
+++ b/test/test_relations_psycopg2.py
@@ -1012,8 +1012,13 @@ LIMIT %s""")
         self.assertEqual(Net.one(ping.id).ip.compressed, "13.14.15.16")
         self.assertEqual(Net.one(pong.id).ip.compressed, "5.6.7.8")
 
-        sis = Sis.many(name="Sally").set(bro_id=[1, 2, 3])
-        self.assertRaisesRegex(relations.ModelError, "cannot update ties in retrieve mode", sis.update)
+        Sis("Sally").create()
+        bro = Bro("Harry").create()
+        Sis.many(name="Sally").set(bro_id=[bro.id]).update()
+
+        sis = Sis.one(name="Sally")
+
+        self.assertEqual(Bro.one(name="Harry").sis.id, [sis.id])
 
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()
@@ -1084,7 +1089,13 @@ LIMIT %s""")
         plain = Plain(0, "nope").create()
         self.assertRaisesRegex(relations.ModelError, "plain: nothing to delete from", plain.delete)
 
-        self.assertRaisesRegex(relations.ModelError, "cannot delete ties in retrieve mode", Sis.many().delete)
+        Sis("Sally").create()
+        bro = Bro("Harry").create()
+        Sis.many(name="Sally").set(bro_id=[bro.id]).update()
+
+        Sis.one(name="Sally").delete()
+
+        self.assertEqual(Bro.one(name="Harry").sis.id, [])
 
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()

--- a/test/test_relations_psycopg2.py
+++ b/test/test_relations_psycopg2.py
@@ -627,8 +627,16 @@ LIMIT %s""")
 
         self.assertEqual(Unit.many(like="p").count(), 1)
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.count)
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        tom = Bro("Tom").create()
+        Sis("Sally", bro_id=[tom.id]).create()
+        Sis("Mary").create()
+
+        self.assertEqual(Sis.many(bro_id=[tom.id]).count(), 1)
+        self.assertEqual(Sis.many(bro_id=[999]).count(), 0)
 
     def test_values_retrieve(self):
 
@@ -839,9 +847,6 @@ LIMIT %s""")
         model = Net.many(subnet__max_value=int(ipaddress.IPv4Address('1.2.3.0')))
         self.assertEqual(len(model), 0)
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.retrieve)
-
         tom = Bro("Tom").create()
         dick = Bro("Dick").create()
 
@@ -853,6 +858,64 @@ LIMIT %s""")
 
         self.assertEqual(mary.bro.id, [dick.id, tom.id])
         self.assertEqual(harry.sis.id, [dot.id, nikki.id])
+
+        self.assertEqual(len(Sis.many(bro_id=[tom.id])), 1)
+        self.assertEqual(Sis.many(bro_id=[tom.id])[0].name, "Mary")
+
+        self.assertEqual(len(Bro.many(sis_id=[dot.id])), 1)
+        self.assertEqual(Bro.many(sis_id=[dot.id])[0].name, "Harry")
+
+        self.assertEqual(len(Sis.many(bro_id=[999])), 0)
+
+    def test_retrieve_ties_query(self):
+
+        self.source.execute(Sis.define())
+        self.source.execute(Bro.define())
+        self.source.execute(SisBro.define())
+
+        # The tie field is a set, so it's queried with set operators (has/any/all),
+        # resolved through the tie table. A sister has many brothers, so "any of" and
+        # "all of" are genuinely different queries.
+
+        tom = Bro("Tom").create()
+        dick = Bro("Dick").create()
+        harry = Bro("Harry").create()
+
+        Sis("Mary", bro_id=[tom.id, dick.id]).create()   # tied to Tom, Dick
+        Sis("Sue", bro_id=[tom.id]).create()             # tied to Tom
+        Sis("Ann", bro_id=[dick.id, harry.id]).create()  # tied to Dick, Harry
+
+        # has: tied to that one brother
+        self.assertEqual(sorted(Sis.many(bro_id__has=tom.id).name), ["Mary", "Sue"])
+        self.assertEqual(Sis.many(bro_id__has=harry.id).name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro_id__has=999)), 0)
+
+        # any: tied to at least one of them
+        self.assertEqual(sorted(Sis.many(bro_id__any=[tom.id, harry.id]).name), ["Ann", "Mary", "Sue"])
+        self.assertEqual(Sis.many(bro_id__any=[harry.id]).name, ["Ann"])
+        self.assertEqual(len(Sis.many(bro_id__any=[999])), 0)
+
+        # all: tied to every one of them
+        self.assertEqual(Sis.many(bro_id__all=[tom.id, dick.id]).name, ["Mary"])
+        self.assertEqual(sorted(Sis.many(bro_id__all=[dick.id]).name), ["Ann", "Mary"])
+        self.assertEqual(len(Sis.many(bro_id__all=[tom.id, harry.id])), 0)
+
+        # all must de-dupe the requested list (a repeated value can't change the result)
+        self.assertEqual(sorted(Sis.many(bro_id__all=[dick.id, dick.id]).name), ["Ann", "Mary"])
+
+        # negation
+        self.assertEqual(Sis.many(bro_id__not_has=tom.id).name, ["Ann"])
+        self.assertEqual(sorted(Sis.many(bro_id__not_any=[harry.id]).name), ["Mary", "Sue"])
+
+        # symmetric: brothers queried by their tied sisters
+        jane = Sis("Jane").create()
+        joan = Sis("Joan").create()
+        Bro("Bob", sis_id=[jane.id, joan.id]).create()   # tied to Jane, Joan
+        Bro("Bill", sis_id=[jane.id]).create()           # tied to Jane
+
+        self.assertEqual(sorted(Bro.many(sis_id__has=jane.id).name), ["Bill", "Bob"])
+        self.assertEqual(Bro.many(sis_id__all=[jane.id, joan.id]).name, ["Bob"])
+        self.assertEqual(Bro.many(sis_id__any=[joan.id]).name, ["Bob"])
 
     def test_titles(self):
 
@@ -901,8 +964,10 @@ LIMIT %s""")
             1: ["1.2.3.4"]
         })
 
-        sis = Sis.many(bro_id=[2, 3, 4])
-        self.assertRaisesRegex(relations.ModelError, "cannot filter ties", sis.titles)
+        tom = Bro("Tom").create()
+        Sis("Sally", bro_id=[tom.id]).create()
+
+        self.assertEqual(len(Sis.many(bro_id=[tom.id]).titles().ids), 1)
 
     def test_update_field(self):
 


### PR DESCRIPTION
Closes #46.

Many-to-Many for this backend (create/update/delete + Select), with M2M Select resolved as an **in-database subquery** via the shared `relations_sql.SOURCE` mixin — no reading ties into Python.

- Inherits `collate_ties`/`collate_ties_query` from `relations_sql.SOURCE` (relations-dil/python-relations-sql#21); local copy removed.
- Functional `test_retrieve_ties_query` validates has/any/all/not_ against a real PostgreSQL. 100% via `make test` **and** `make lint`.

**Supersedes #42** — that branch's CUD commits are already merged into this one.

Merge order — land first: core relations-dil/python-relations#62 and the mixin relations-dil/python-relations-sql#21 (this pins both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)